### PR TITLE
GitHub Fix

### DIFF
--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -894,10 +894,10 @@ namespace linerider
             var size = (Screen.PrimaryScreen.Bounds.Width / 1600 < Screen.PrimaryScreen.Bounds.Height / 1080) ? (Screen.PrimaryScreen.Bounds.Width / 1600) : (Screen.PrimaryScreen.Bounds.Height / 1080);
             if (size < 1) { size = 1; };
             Cursors[name] = new MouseCursor(hotx, hoty, image.Width, image.Height, data.Scan0);
-            Debug.WriteLine(Cursors[name]);
-            Debug.WriteLine(size);
-            Debug.WriteLine(image.Width);
-            Debug.WriteLine(image.Width * size / 4);
+            //Debug.WriteLine(Cursors[name]);
+            //Debug.WriteLine(size);
+            //Debug.WriteLine(image.Width);
+            //Debug.WriteLine(image.Width * size / 4);
             image.UnlockBits(data);
         }
         private void RegisterHotkeys()

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -197,7 +197,7 @@ namespace linerider
                     {
                         using (WebClient wc = new WebClient())
                         {
-                            string currentversion = wc.DownloadString($"{Constants.GithubRawHeader}/main/version");
+                            string currentversion = wc.DownloadString($"{Constants.GithubApiHeader}/releases");
                             var idx = currentversion.IndexOfAny(new char[] { '\r', '\n' });
                             if (idx != -1)
                             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -40,7 +40,7 @@ namespace linerider
         public static string Version = "1.5.0.2";
         public static string TestVersion = "a";
         public static string NewVersion = null;
-        public static readonly string WindowTitle = "Line Rider Advanced - Community || " + Version + TestVersion;
+        public static readonly string WindowTitle = "Line Rider Overhaul || " + Version + TestVersion;
         public static Random Random;
         private static bool _crashed;
         private static MainWindow glGame;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -197,7 +197,7 @@ namespace linerider
                     {
                         using (WebClient wc = new WebClient())
                         {
-                            string currentversion = wc.DownloadString($"{Constants.GithubApiHeader}/releases");
+                            string currentversion = wc.DownloadString($"{Constants.GithubRawHeader}/main/version");
                             var idx = currentversion.IndexOfAny(new char[] { '\r', '\n' });
                             if (idx != -1)
                             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -37,7 +37,7 @@ namespace linerider
 #endif
         public static string BinariesFolder = "bin";
         public readonly static CultureInfo Culture = new CultureInfo("en-US");
-        public static string Version = "LRL Cleanup Update 1.5.0.2";
+        public static string Version = "1.5.0.2";
         public static string TestVersion = "a";
         public static string NewVersion = null;
         public static readonly string WindowTitle = "Line Rider Advanced - Community || " + Version + TestVersion;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -38,7 +38,7 @@ namespace linerider
         public static string BinariesFolder = "bin";
         public readonly static CultureInfo Culture = new CultureInfo("en-US");
         public static string Version = "LRL Cleanup Update 1.5.0.2";
-        public static string TestVersion = "test_version";
+        public static string TestVersion = "a";
         public static string NewVersion = null;
         public static readonly string WindowTitle = "Line Rider Advanced - Community || " + Version + TestVersion;
         public static Random Random;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -187,36 +187,36 @@ namespace linerider
         }
         public static void UpdateCheck()
         {
-            //if (TestVersion.Contains("closed"))
-            //    return;
-            //if (Settings.CheckForUpdates)
-            //{
-            //    new System.Threading.Thread(() =>
-            //    {
-            //        try
-            //        {
-            //            using (WebClient wc = new WebClient())
-            //            {
-            //                string currentversion = wc.DownloadString($"{Constants.GithubRawHeader}/master/version");
-            //                var idx = currentversion.IndexOfAny(new char[] { '\r', '\n' });
-            //                if (idx != -1)
-            //                {
-            //                    currentversion = currentversion.Remove(idx);
-            //                }
-            //                if (currentversion != Version && currentversion.Length > 0)
-            //                {
-            //                    NewVersion = currentversion;
-            //                }
-            //            }
-            //        }
-            //        catch
-            //        {
-            //        }
-            //    })
-            //    {
-            //        IsBackground = true
-            //    }.Start();
-            //}
+            if (TestVersion.Contains("closed"))
+                return;
+            if (Settings.CheckForUpdates)
+            {
+                new System.Threading.Thread(() =>
+                {
+                    try
+                    {
+                        using (WebClient wc = new WebClient())
+                        {
+                            string currentversion = wc.DownloadString($"{Constants.GithubRawHeader}/main/version");
+                            var idx = currentversion.IndexOfAny(new char[] { '\r', '\n' });
+                            if (idx != -1)
+                            {
+                                currentversion = currentversion.Remove(idx);
+                            }
+                            if (currentversion != Version && currentversion.Length > 0)
+                            {
+                                NewVersion = currentversion;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                    }
+                })
+                {
+                    IsBackground = true
+                }.Start();
+            }
         }
         public static int GetWindowWidth()
         {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -38,7 +38,7 @@ namespace linerider
         public static string BinariesFolder = "bin";
         public readonly static CultureInfo Culture = new CultureInfo("en-US");
         public static string Version = "LRL Cleanup Update 1.5.0.2";
-        public static string TestVersion = "a";
+        public static string TestVersion = "test_version";
         public static string NewVersion = null;
         public static readonly string WindowTitle = "Line Rider Advanced - Community || " + Version + TestVersion;
         public static Random Random;

--- a/src/Utils/Constants.cs
+++ b/src/Utils/Constants.cs
@@ -48,7 +48,7 @@ namespace linerider.Utils
         : Color.FromArgb(ColorWhite.ToArgb());
 
         public static readonly string GithubPageHeader = "https://github.com/LunaKampling/LROverhaul";
-        public static readonly string GithubRawHeader = "https://raw.githubusercontent.com/LunaKampling/LROverhaul";
+        public static readonly string GithubApiHeader = "https://api.github.com/repos/LunaKampling/LROverhaul";
         public static readonly string FfmpegHelperHeader = "https://github.com/jealouscloud/lra-ffmpeg/releases/download/ffmpeg4.0-x64/ffmpeg";
     }
 }

--- a/src/Utils/Constants.cs
+++ b/src/Utils/Constants.cs
@@ -48,7 +48,7 @@ namespace linerider.Utils
         : Color.FromArgb(ColorWhite.ToArgb());
 
         public static readonly string GithubPageHeader = "https://github.com/LunaKampling/LROverhaul";
-        public static readonly string GithubApiHeader = "https://api.github.com/repos/LunaKampling/LROverhaul";
+        public static readonly string GithubRawHeader = "https://raw.githubusercontent.com/LunaKampling/LROverhaul";
         public static readonly string FfmpegHelperHeader = "https://github.com/jealouscloud/lra-ffmpeg/releases/download/ffmpeg4.0-x64/ffmpeg";
     }
 }


### PR DESCRIPTION
Created a releases page and made the link redirect to the releases page. Renamed the current version to just be the version number.

Also, commented out some logging code for the cursors.