### PR TITLE
Minor Changes

### DIFF
--- a/src/UI/Components/Playhead.cs
+++ b/src/UI/Components/Playhead.cs
@@ -134,6 +134,7 @@ namespace linerider.UI.Components
             KeyboardInputEnabled = false;
             MouseInputEnabled = true;
             RestrictToParent = true;
+            ToolTipProvider = true;
             IsTabable = false;
             m_Target = this;
 

--- a/src/UI/Components/Playhead.cs
+++ b/src/UI/Components/Playhead.cs
@@ -82,6 +82,11 @@ namespace linerider.UI.Components
         public bool AllowDragging = true;
 
         /// <summary>
+        /// Function to define the tooltip text before render.
+        /// </summary>
+        public TextRequestHandler TooltipRequest = null;
+
+        /// <summary>
         /// Playhead position relative to slider. Auto adopts UI scale.
         /// Set negative value to put it above the slider or positive value to put it below.
         /// </summary>
@@ -233,6 +238,14 @@ namespace linerider.UI.Components
 
             double raw = (double)(value - Min) / (Max - Min);
             X = (int)Math.Round(MinX + raw * (MaxX - MinX));
+        }
+        public override void Think()
+        {
+            if (TooltipRequest != null)
+            {
+                Tooltip = TooltipRequest(this, Tooltip);
+            }
+            base.Think();
         }
 
         protected override void Render(Gwen.Skin.SkinBase skin)

--- a/src/UI/Dialogs/PreferencesWindow.cs
+++ b/src/UI/Dialogs/PreferencesWindow.cs
@@ -309,14 +309,18 @@ namespace linerider.UI
                 Dock = Dock.Left,
                 ShouldDrawBackground = false,
             };
-            _ = pbzoom.AddOption("Default Zoom");
-            _ = pbzoom.AddOption("Current Zoom");
-            _ = pbzoom.AddOption("Specific Zoom");
+            RadioButton pbzoomOpt1 = pbzoom.AddOption("Frame Zoom");
+            RadioButton pbzoomOpt2 = pbzoom.AddOption("Current Camera Zoom (Default)");
+            RadioButton pbzoomOpt3 = pbzoom.AddOption("Specific Value");
+
+            pbzoomOpt1.Tooltip = "When playing, zoom matches current frame zoom\n(e.g.value set by a trigger).";
+            pbzoomOpt2.Tooltip = "When playing, zoom stays as is\n(no zoom jumps on playing track).";
+            pbzoomOpt3.Tooltip = "When playing, zoom sets to one specific value.";
 
             Spinner specificzoomspinner = new Spinner(zoomGroup)
             {
-                Max = 24,
-                Min = 1,
+                Max = Constants.MaxZoom,
+                Min = Constants.MinimumZoom,
             };
 
             // A bit hacky but simplest way to show compact zoom spinner next to a radio button

--- a/src/UI/Dialogs/PreferencesWindow.cs
+++ b/src/UI/Dialogs/PreferencesWindow.cs
@@ -1003,7 +1003,10 @@ namespace linerider.UI
             };
             _ = GwenHelper.CreateLabeledControl(savesGroup, "Minimum Changes to Autosave", autosaveChanges);
 
-            TextBox autosaveName = new TextBox(savesGroup);
+            TextBox autosaveName = new TextBox(savesGroup)
+            {
+                Width = 100,
+            };
             autosaveName.Text = Settings.AutosavePrefix;
             autosaveName.TextChanged += (o, e) =>
             {

--- a/src/UI/Widgets/ZoomBar.cs
+++ b/src/UI/Widgets/ZoomBar.cs
@@ -155,7 +155,13 @@ namespace linerider.UI.Widgets
             _playheadDefaultZoom.IsHidden = !_editor.UseUserZoom && _editor.BaseZoom == _editor.Timeline.GetFrameZoom(_editor.Offset);
 
             if (!_playheadDefaultZoom.IsHidden)
-                _playheadDefaultZoom.Value = ZoomToSliderValue(_editor.Timeline.GetFrameZoom(_editor.Offset));
+            {
+                float frameZoom = _editor.Timeline.GetFrameZoom(_editor.Offset);
+                _playheadDefaultZoom.Value = ZoomToSliderValue(frameZoom);
+                _playheadDefaultZoom.Tooltip = $"Frame actual zoom: {frameZoom}x\nClick to set as current zoom";
+                if (Hotkey.PlaybackResetCamera != Hotkey.None)
+                    _playheadDefaultZoom.Tooltip += $" (or press {Settings.HotkeyToString(Hotkey.PlaybackResetCamera)})";
+            }
 
             if (!_slider.Playhead.IsHeld && (_prevBaseZoom != _editor.BaseZoom || _prevSuperZoom != Settings.SuperZoom))
             {

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -267,8 +267,8 @@ namespace linerider
             Bezier.Resolution = 30;
             Bezier.NodeSize = 15;
             Bezier.Mode = (int)BezierMode.Direct;
-            PlaybackZoomType = 0;
-            PlaybackZoomValue = 4;
+            PlaybackZoomType = 1;
+            PlaybackZoomValue = Constants.DefaultZoom;
             Volume = 100;
             SuperZoom = false;
             NightMode = false;


### PR DESCRIPTION
* Preferences: renamed "Playback Zoom" options and added tooltips
* Preferences: set "Current Zoom" as default playback zoom option
* Preferences: shorter "Minimum Changes to Autosave" input field.
* UI: added a tooltip to the default zoom playhead (ex "reset camera" button)