### PR TITLE
stub System.Windows.Forms calls

### DIFF
--- a/src/Addons/Coordinates.cs
+++ b/src/Addons/Coordinates.cs
@@ -1,6 +1,7 @@
 using linerider.Game;
 using linerider.Rendering;
-using System.Windows.Forms;
+using System;
+//using System.Windows.Forms;
 
 namespace linerider.Addons
 {
@@ -61,10 +62,14 @@ namespace linerider.Addons
             iteration = game.Track.IterationsOffset;
             Rider rider = game.Track.Timeline.GetFrame(frame, iteration);
 
-            if (xClipboard)
-                Clipboard.SetText(rider.Body[integerClipboard].Location.X.ToString("G17"));
-            if (yClipboard)
-                Clipboard.SetText(rider.Body[integerClipboard].Location.Y.ToString("G17"));
+            if (OperatingSystem.IsWindows()) {
+                /* TODO replace, maybe glfw clipboard api
+                if (xClipboard)
+                    Clipboard.SetText(rider.Body[integerClipboard].Location.X.ToString("G17"));
+                if (yClipboard)
+                    Clipboard.SetText(rider.Body[integerClipboard].Location.Y.ToString("G17"));
+                */
+            }
         }
     };
 }

--- a/src/GameCanvas.cs
+++ b/src/GameCanvas.cs
@@ -277,20 +277,24 @@ namespace linerider
         public static bool ShowLoadCrashBackup(string name)
         {
             bool ret = false;
-            string text = "" +
-                "Hey, it looks like you are trying to load a Crash Backup.\n" +
-                "(" + name + ")\n" +
-                "Some issues with the save may cause the file to always crash this program.\n" +
-                "Are you sure you want to load it?";
-            string title = "So about that crash backup...";
 
-            if (System.Windows.Forms.MessageBox.Show(text, title,
-                System.Windows.Forms.MessageBoxButtons.YesNo)
-                 == System.Windows.Forms.DialogResult.Yes)
-            {
-                ret = true;
-                Settings.LastSelectedTrack = "";
-                Settings.Save();
+            if (System.OperatingSystem.IsWindows()) {
+                /* TODO MessageBox from user32.dll instead of winforms
+                string text = "" +
+                    "Hey, it looks like you are trying to load a Crash Backup.\n" +
+                    "(" + name + ")\n" +
+                    "Some issues with the save may cause the file to always crash this program.\n" +
+                    "Are you sure you want to load it?";
+                string title = "So about that crash backup...";
+                
+                if (System.Windows.MessageBox.Show(text, title,
+                    System.Windows.Forms.MessageBoxButtons.YesNo)
+                    == System.Windows.Forms.DialogResult.Yes)
+                {
+                    ret = true;
+                    Settings.LastSelectedTrack = "";
+                    Settings.Save();
+                }*/
             }
             return ret;
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -114,31 +114,39 @@ namespace linerider
             string title = "Game crashed!";
             string msg = $"Unhandled Exception: {e.Message}{msgBoxSpearator}{e.StackTrace}{msgBoxSpearator}{msgBoxSpearator}Would you like to export the crash data to a log file?{msgBoxSpearator}Log file path: {logFilePath}";
 
-            System.Windows.Forms.DialogResult btn = System.Windows.Forms.MessageBox.Show(msg, title, System.Windows.Forms.MessageBoxButtons.YesNo, System.Windows.Forms.MessageBoxIcon.Error);
+            if (OperatingSystem.IsWindows()) {
+                /* TODO MessageBox from user32.dll instead of winforms
+                System.Windows.Forms.DialogResult btn = System.Windows.Forms.MessageBox.Show(msg, title, System.Windows.Forms.MessageBoxButtons.YesNo, System.Windows.Forms.MessageBoxIcon.Error);
 
-            if (btn == System.Windows.Forms.DialogResult.Yes)
-            {
-                string now = DateTime.Now.ToString("yyyy-MM-dd HH':'mm':'ss");
-                string headerSeparator = new string('-', 3);
-                string header = $"{headerSeparator} {AssemblyInfo.FullVersion} {headerSeparator} {now} {headerSeparator}";
-                string newLine = "\r\n";
+                if (btn == System.Windows.Forms.DialogResult.Yes)
+                {
+                    string now = DateTime.Now.ToString("yyyy-MM-dd HH':'mm':'ss");
+                    string headerSeparator = new string('-', 3);
+                    string header = $"{headerSeparator} {AssemblyInfo.FullVersion} {headerSeparator} {now} {headerSeparator}";
+                    string newLine = "\r\n";
 
-                if (!File.Exists(logFilePath))
-                    File.Create(logFilePath).Dispose();
+                    if (!File.Exists(logFilePath))
+                        File.Create(logFilePath).Dispose();
 
-                string oldRecords = File.ReadAllText(logFilePath, System.Text.Encoding.UTF8);
-                string newRecord = header + newLine + newLine + e.ToString() + newLine;
-                if (!string.IsNullOrEmpty(oldRecords))
-                    newRecord = newLine + newRecord;
+                    string oldRecords = File.ReadAllText(logFilePath, System.Text.Encoding.UTF8);
+                    string newRecord = header + newLine + newLine + e.ToString() + newLine;
+                    if (!string.IsNullOrEmpty(oldRecords))
+                        newRecord = newLine + newRecord;
 
-                File.WriteAllText(logFilePath, oldRecords + newRecord, System.Text.Encoding.UTF8);
+                    File.WriteAllText(logFilePath, oldRecords + newRecord, System.Text.Encoding.UTF8);
+                }*/
             }
 
             if (!nothrow)
                 throw e;
         }
 
-        public static void NonFatalError(string err) => System.Windows.Forms.MessageBox.Show("Non Fatal Error: " + err);
+        public static void NonFatalError(string err) { 
+            if (OperatingSystem.IsWindows()) {
+                /* TODO MessageBox from user32.dll instead of winforms
+                System.Windows.Forms.MessageBox.Show("Non Fatal Error: " + err);
+            */}
+        }
         public static void Run(string[] givenArgs)
         {
             if (Debugger.IsAttached)

--- a/src/Tools/SelectSubtool.cs
+++ b/src/Tools/SelectSubtool.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text;
-using System.Windows.Forms;
+//using System.Windows.Forms;
 using System.Diagnostics;
 
 namespace linerider.Tools
@@ -493,19 +493,27 @@ namespace linerider.Tools
                 }
             }
 
-            Clipboard.SetText(lineArray.ToString() + "]");
+            if (OperatingSystem.IsWindows()) {
+                /* TODO replace, maybe glfw clipboard api           
+                Clipboard.SetText(lineArray.ToString() + "]");
+                */
+            }
 
             game.Track.Notify("Copied!");
         }
         public void PasteValues()
         {
-            string lineArray = Clipboard.GetText();
-            List<GameLine> lineList = ParseJson(lineArray);
+            if (OperatingSystem.IsWindows()) {
+                /* TODO replace, maybe glfw clipboard api
+                string lineArray = Clipboard.GetText();
+                List<GameLine> lineList = ParseJson(lineArray);
 
-            if (lineList is null)
-                return;
+                if (lineList is null)
+                    return;
 
-            PasteFromBuffer(lineList);
+                PasteFromBuffer(lineList);
+                */
+            }
         }
         private List<GameLine> ParseJson(string lineArray)
         {

--- a/src/UI/PlatformImpl.cs
+++ b/src/UI/PlatformImpl.cs
@@ -19,7 +19,7 @@
 using OpenTK;
 using System;
 using System.Threading;
-using System.Windows.Forms;
+//using System.Windows.Forms;
 
 namespace linerider.UI
 {
@@ -39,7 +39,11 @@ namespace linerider.UI
                 {
                     try
                     {
-                        Clipboard.SetText(text);
+                        if (OperatingSystem.IsWindows()) {
+                            /* TODO replace, maybe glfw clipboard api   
+                            Clipboard.SetText(text);
+                            */
+                        }
                         ret = true;
                     }
                     catch (Exception)
@@ -47,7 +51,7 @@ namespace linerider.UI
                         return;
                     }
                 });
-            staThread.SetApartmentState(ApartmentState.STA);
+            if (OperatingSystem.IsWindows()) staThread.SetApartmentState(ApartmentState.STA);
             staThread.Start();
             staThread.Join();
             // At this point either you have clipboard data or an exception
@@ -62,16 +66,20 @@ namespace linerider.UI
                 {
                     try
                     {
-                        if (!Clipboard.ContainsText())
-                            return;
-                        ret = Clipboard.GetText();
+                        if (OperatingSystem.IsWindows()) {
+                            /* TODO replace, maybe glfw clipboard api   
+                            if (!Clipboard.ContainsText())
+                                return;
+                            ret = Clipboard.GetText();
+                            */
+                        }
                     }
                     catch (Exception)
                     {
                         return;
                     }
                 });
-            staThread.SetApartmentState(ApartmentState.STA);
+            if (OperatingSystem.IsWindows()) staThread.SetApartmentState(ApartmentState.STA);
             staThread.Start();
             staThread.Join();
             // At this point either you have clipboard data or an exception

--- a/src/Utils/Constants.cs
+++ b/src/Utils/Constants.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Drawing;
 using System.IO;
-using System.Windows.Forms;
+//using System.Windows.Forms;
 
 namespace linerider.Utils
 {
@@ -67,7 +67,9 @@ namespace linerider.Utils
         public const float KnobSize = 0.8f;
         public const float MaxLimitedKnobSize = MaxZoom;
 
-        public static readonly Size ScreenSize = new Size(Screen.PrimaryScreen.Bounds.Width, Screen.PrimaryScreen.Bounds.Height);
+        // PLACEHOLDER
+        public static readonly Size ScreenSize = new Size(1920, 1080);
+        // TODO replace with opentk monitorinfo API: public static readonly Size ScreenSize = new Size(Screen.PrimaryScreen.Bounds.Width, Screen.PrimaryScreen.Bounds.Height);
         public static readonly double ScreenScale = Math.Max(1,
             Math.Round(((double)ScreenSize.Width / 1600 < (double)ScreenSize.Height / 1080)
                 ? ((double)ScreenSize.Width / 1600)

--- a/src/linerider.csproj
+++ b/src/linerider.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
     <AllowedReferenceRelatedFileExtensions>
       *.pdb;
     </AllowedReferenceRelatedFileExtensions>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UseWindowsForms>true</UseWindowsForms>
+    <!--<UseWindowsForms>true</UseWindowsForms>-->
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This gets rid of winforms calls and changes the project settings so it isn't building for `net8.0-windows` and `WinExe`.

Regressions:
- clipboard functionality is missing (opentk has an api we can use)
- screen size detection is missing (opentk has an api we can use)
- messageboxes are missing (could just call user32 for this on windows)
- changing the output type from `WinExe` to `Exe` makes the console window appear when running on windows, maybe this could be conditionally chosen depending on the target OS.