### PR TITLE
subiterations viewer

### DIFF
--- a/src/Addons/Coordinates.cs
+++ b/src/Addons/Coordinates.cs
@@ -43,9 +43,7 @@ namespace linerider.Addons
         public static void CoordsUpdate()
         {
             MainWindow game = GameRenderer.Game;
-            frame = game.Track.Offset;
-            iteration = game.Track.IterationsOffset;
-            Rider rider = game.Track.Timeline.GetFrame(frame, iteration);
+            Rider rider = game.Track.Timeline.GetFrame(game.Track.momentOffset);
 
             for (int i = 0; i < ConPName.Length; i++)
             {

--- a/src/Addons/MagicAnimator.cs
+++ b/src/Addons/MagicAnimator.cs
@@ -18,14 +18,14 @@ namespace linerider.Addons
         {
             RiderFrame flag = window.Track.Flag;
             int currentFrame = window.Track.Offset;
-            if (flag == null || currentFrame <= flag.FrameID)
+            if (flag == null || currentFrame <= flag.Moment.Frame)
             {
                 // Behavior only defined if flag is set and current frame is ahead of it
                 return;
             }
 
             Rider flagFrameRider = flag.State;
-            Rider flagNextFrameRider = window.Track.Timeline.ExtractFrame(flag.FrameID + 1).State;
+            Rider flagNextFrameRider = window.Track.Timeline.ExtractFrame(flag.Moment.Frame + 1).State;
 
             // Where the Rider was at the flag frame, and the frame after that
             // This establishes the initial frame of reference
@@ -43,7 +43,7 @@ namespace linerider.Addons
             // Add the user-configurable speed offsets
             firstFrameDiff = Vector2d.Add(firstFrameDiff, new Vector2d(Settings.animationRelativeVelX, Settings.animationRelativeVelY));
 
-            int framesElapsed = currentFrame - flag.FrameID;
+            int framesElapsed = currentFrame - flag.Moment.Frame;
 
             // Apply the speed vector to the number of elapsed frames, and add it to the initial reference frame
             // to get an expected position for the current frame
@@ -160,7 +160,7 @@ namespace linerider.Addons
             }
             RiderFrame flag = window.Track.Flag;
             int currentFrame = window.Track.Offset;
-            int framesElapsed = currentFrame - flag.FrameID;
+            int framesElapsed = currentFrame - flag.Moment.Frame;
 
             window.Invalidate();
             window.Track.UndoManager.BeginAction();

--- a/src/Drawing/DrawOptions.cs
+++ b/src/Drawing/DrawOptions.cs
@@ -1,4 +1,5 @@
 using linerider.Game;
+using linerider.Game.Physics;
 using System.Collections.Generic;
 
 namespace linerider.Drawing
@@ -18,7 +19,7 @@ namespace linerider.Drawing
         public List<int> RiderDiagnosis = null;
         public bool ShowContactLines = false;
         public bool ShowMomentumVectors = false;
-        public int Iteration = 6;
+        public Moment Moment;
         public float Zoom;
         public int OverlayFrame = -1;
         public bool IsRunning => !Paused;

--- a/src/Editor.cs
+++ b/src/Editor.cs
@@ -392,7 +392,6 @@ namespace linerider
                 drawOptions.Rider = Rider.Lerp(prev, current, blend);
                 renderframe = Offset - 1;
             }
-            //drawOptions.Iteration = IterationsOffset;
             drawOptions.Moment = momentOffset;
             // TODO: there's a race condition here where if the track finished 
             // loading between this if statement and the render call above

--- a/src/Game/Lines/RedLine.cs
+++ b/src/Game/Lines/RedLine.cs
@@ -57,15 +57,17 @@ namespace linerider.Game
             _acc = DiffNormal * (ConstAcc * _multiplier);
             _acc = inv ? _acc.PerpendicularRight : _acc.PerpendicularLeft;
         }
-        public override bool Interact(ref SimulationPoint p)
+
+        public override bool Interact(ref SimulationPoint p, bool frictionless = false, bool accelless = false)
         {
             if (base.Interact(ref p))
             {
-                p = p.Replace(p.Location, p.Previous + _acc);
+                p = p.Replace(p.Location, p.Previous + (!accelless ? _acc : Vector2d.Zero));
                 return true;
             }
             return false;
         }
+
         public override GameLine Clone()
         {
             LineTrigger trigger = null;

--- a/src/Game/Lines/StandardLine.cs
+++ b/src/Game/Lines/StandardLine.cs
@@ -96,7 +96,8 @@ namespace linerider.Game
             DiffNormal = inv ? DiffNormal.PerpendicularRight : DiffNormal.PerpendicularLeft;
             ExtensionRatio = Math.Min(0.25, Zone / Distance);
         }
-        public virtual bool Interact(ref SimulationPoint p)
+
+        public virtual bool Interact(ref SimulationPoint p, bool frictionless = false, bool accelless = false)
         {
             if (Vector2d.Dot(p.Momentum, DiffNormal) > 0)
             {
@@ -109,7 +110,7 @@ namespace linerider.Game
                     {
                         Vector2d pos = p.Location - disty * DiffNormal;
                         _ = p.Previous;
-                        if (p.Friction != 0)
+                        if (!frictionless && p.Friction != 0)
                         {
                             Vector2d friction = DiffNormal.Yx * p.Friction * disty;
                             if (p.Previous.X >= pos.X)

--- a/src/Game/Physics/ImmutablePointCollection.cs
+++ b/src/Game/Physics/ImmutablePointCollection.cs
@@ -47,13 +47,13 @@ namespace linerider.Game
             }
             return true;
         }
-        public SimulationPoint[] Step(bool friction = false)
+        public SimulationPoint[] Step(bool friction = false, bool gravity = true)
         {
             int len = _points.Length;
             SimulationPoint[] ret = new SimulationPoint[len];
             for (int i = 0; i < len; i++)
             {
-                ret[i] = !friction ? _points[i].Step() : _points[i].StepFriction();
+                ret[i] = !friction ? _points[i].Step(gravity) : _points[i].StepFriction();
             }
             return ret;
         }

--- a/src/Game/Physics/Moment.cs
+++ b/src/Game/Physics/Moment.cs
@@ -1,0 +1,237 @@
+namespace linerider.Game.Physics
+{
+    /// <summary>
+    /// describes a very specific point in the physics simulation, can include intermediate steps like iterations, subiterations, and the individual components of a momentum tick.
+    /// </summary>
+    public class Moment
+    {
+        private int frame;
+        private int iteration;
+        private int subiteration;
+
+        public int Frame { get { return frame; } set { frame = value; } }
+        public int Iteration { get { return iteration; } set { iteration = value; } }
+        public int Subiteration { get { return subiteration; } set { subiteration = value; } }
+
+        public Moment(int frame, int iteration = RiderConstants.Iterations,
+            int subiteration = RiderConstants.Subiterations)
+        {
+            this.frame = frame;
+            this.iteration = iteration;
+            this.subiteration = subiteration;
+        }
+        
+        public bool interactWithLines()
+        {
+            return iteration != 0 && subiteration == RiderConstants.Subiterations;
+        }
+
+        public static bool operator <(Moment a, Moment b)
+        {
+            if (a.frame < b.frame) return true;
+            if (a.iteration < b.iteration) return true;
+            if (a.subiteration < b.subiteration) return true;
+            return false;
+        }
+
+        public static bool operator >(Moment a, Moment b)
+        {
+            return b < a;
+        }
+        
+        public static bool operator <=(Moment a, Moment b)
+        {
+            if (a.frame < b.frame) return true;
+            if (a.iteration < b.iteration) return true;
+            if (a.subiteration < b.subiteration) return true;
+            if (a.frame == b.frame && a.iteration == b.iteration && a.subiteration == b.subiteration) return true;
+            return false;
+        }
+
+        public static bool operator >=(Moment a, Moment b)
+        {
+            return b <= a;
+        }
+
+        public void IncrementFrame()
+        {
+            frame++;
+            iteration = RiderConstants.Iterations;
+            subiteration = maxSubiteration(iteration);
+        }
+
+        public Moment NextFrame()
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.IncrementFrame();
+            return obj;
+        }
+
+        public Moment WithFrame(int fr)
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.Frame = fr;
+            return obj;
+        }
+
+        public void DecrementFrame()
+        {
+            if (frame == 0) return;
+            frame--;
+            iteration = RiderConstants.Iterations;
+            subiteration = maxSubiteration(iteration);
+        }
+
+        public Moment PreviousFrame()
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.DecrementFrame();
+            return obj;
+        }
+
+        public void IncrementIteration()
+        {
+            if (iteration >= RiderConstants.Iterations)
+            {
+                IncrementFrame();
+                iteration = 0;
+                subiteration = maxSubiteration(iteration);
+            }
+            else
+            {
+                iteration++;
+                subiteration = maxSubiteration(iteration);
+            }
+        }
+
+        public Moment NextIteration()
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.IncrementIteration();
+            return obj;
+        }
+
+        public Moment WithIteration(int iter)
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.Iteration = iter;
+            return obj;
+        }
+
+        public void DecrementIteration()
+        {
+            if (frame == 0) return;
+            if (iteration == 0)
+            {
+                DecrementFrame();
+            }
+            else
+            {
+                iteration--;
+                subiteration = maxSubiteration(iteration);
+            }
+        }
+
+        public Moment PreviousIteration()
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.DecrementIteration();
+            return obj;
+        }
+
+        public void IncrementSubiteration()
+        {
+            if (subiteration >= maxSubiteration(iteration))
+            {
+                IncrementIteration();
+                subiteration = 0;
+            }
+            else
+            {
+                subiteration++;
+            }
+        }
+
+        public Moment NextSubiteration()
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.IncrementSubiteration();
+            return obj;
+        }
+
+        public Moment WithSubiteration(int subit)
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.subiteration = subit;
+            return obj;
+        }
+
+        public void DecrementSubiteration()
+        {
+            if (frame == 0) return;
+            if (subiteration == 0)
+            {
+                DecrementIteration();
+            }
+            else
+            {
+                subiteration--;
+            }
+        }
+
+        public Moment PreviousSubiteration()
+        {
+            var obj = (Moment)this.MemberwiseClone();
+            obj.DecrementSubiteration();
+            return obj;
+        }
+
+        public string displayString()
+        {
+            string value = "";
+            if (iteration != RiderConstants.Iterations || subiteration != maxSubiteration(iteration))
+            {
+                value += $"Iteration {iteration} ";
+            }
+
+            if (subiteration != maxSubiteration(iteration))
+            {
+                string subiterationName = "";
+                if (iteration != 0)
+                {
+                    var bone = RiderConstants.Bones[subiteration];
+                    subiterationName = $"{RiderConstants.contactPointName(bone.joint1)}-{RiderConstants.contactPointName(bone.joint2)}";
+                }
+                else
+                {
+                    switch (subiteration)
+                    {
+                        case 0:
+                            subiterationName = "Momentum";
+                            break;
+                        case 1:
+                            subiterationName = "Friction";
+                            break;
+                        case 2:
+                            subiterationName = "Acceleration";
+                            break;
+                    }
+                }
+
+                value += $"Subiteration {subiteration} ({subiterationName})";
+            }
+            return value;
+        }
+
+        // for normal iterations, we have 22 bones and then a line collision step
+        // for the momentum tick it is broken into these subiterations:
+        // - initial momentum
+        // - friction
+        // - acceleration multipliers
+        // - gravity (final position of the momentum tick)
+        public static int maxSubiteration(int iteration)
+        {
+            return iteration == 0 ? 3 : RiderConstants.Subiterations;
+        }
+    }
+}

--- a/src/Game/Physics/RiderConstants.cs
+++ b/src/Game/Physics/RiderConstants.cs
@@ -61,6 +61,39 @@ namespace linerider.Game
         public const int BodyHandRight = 7;
         public const int BodyFootLeft = 8;
         public const int BodyFootRight = 9;
+
+        public static string contactPointName(int contactPoint)
+        {
+            switch (contactPoint)
+            {
+                case SledTL:
+                    return "SledTL";
+                case SledBL:
+                    return "SledBL";
+                case SledBR:
+                    return "SledBR";
+                case SledTR:
+                    return "SledTR";
+                case BodyButt:
+                    return "BodyButt";
+                case BodyShoulder:
+                    return "BodyShoulder";
+                case BodyHandLeft:
+                    return "BodyHandLeft";
+                case BodyHandRight:
+                    return "BodyHandRight";
+                case BodyFootLeft:
+                    return "BodyFootLeft";
+                case BodyFootRight:
+                    return "BodyFootRight";
+            }
+
+            return "?";
+        }
+
+        public const int Iterations = 6;
+        public const int Subiterations = 22;
+
         public static readonly Bone[] Bones;
         public static Bone[] ScarfBones;
         static RiderConstants()

--- a/src/Game/Physics/SimulationPoint.cs
+++ b/src/Game/Physics/SimulationPoint.cs
@@ -18,9 +18,9 @@ namespace linerider.Game
             Friction = friction;
             Momentum = momentum;
         }
-        public SimulationPoint Step()
+        public SimulationPoint Step(bool gravity = true)
         {
-            Vector2d momentum = Location - Previous + RiderConstants.Gravity;
+            Vector2d momentum = Location - Previous + (gravity ? RiderConstants.Gravity : Vector2d.Zero);
             return new SimulationPoint(Location + momentum, Location, momentum, Friction);
         }
         public SimulationPoint StepFriction()

--- a/src/Game/RiderFrame.cs
+++ b/src/Game/RiderFrame.cs
@@ -26,10 +26,8 @@ namespace linerider.Game
     /// </summary>
     public class RiderFrame
     {
-        //public int FrameID;
         public Rider State;
         public List<int> Diagnosis;
-        //public int IterationID = 6;
         public Moment Moment;
         public RiderFrame()
         {

--- a/src/Game/RiderFrame.cs
+++ b/src/Game/RiderFrame.cs
@@ -16,6 +16,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using linerider.Game.Physics;
 using System.Collections.Generic;
 
 namespace linerider.Game
@@ -25,19 +26,19 @@ namespace linerider.Game
     /// </summary>
     public class RiderFrame
     {
-        public int FrameID;
+        //public int FrameID;
         public Rider State;
         public List<int> Diagnosis;
-        public int IterationID = 6;
+        //public int IterationID = 6;
+        public Moment Moment;
         public RiderFrame()
         {
         }
-        public RiderFrame(int frameid, Rider state, List<int> diagnosis, int iterationid)
+        public RiderFrame(Moment moment, Rider state, List<int> diagnosis)
         {
-            FrameID = frameid;
+            Moment = moment;
             State = state;
             Diagnosis = diagnosis;
-            IterationID = iterationid;
         }
     }
 }

--- a/src/Game/Timeline.cs
+++ b/src/Game/Timeline.cs
@@ -169,24 +169,8 @@ namespace linerider.Game
         /// </summary>
         public List<int> DiagnoseFrame(Moment moment)
         {
-            if (moment.Subiteration == Moment.maxSubiteration(moment.Iteration)) return DiagnoseFrame(moment.Frame, moment.Iteration);
-            bool equal = false;
-            Rider? rider = null;
-            if (moment.Iteration == RiderConstants.Iterations)
-            {
-                equal = true;
-            }
-            else
-            {
-                Rider next = GetFrame(moment.Frame + 1);
-                rider = GetFrame(moment.Frame);
-            }
-            return equal
-                ? new List<int>()
-                : ((Rider)rider).Diagnose(
-                    _track.Grid,
-                    _track.Bones,
-                    moment.NextIteration());
+            var prev = moment.Subiteration == Moment.maxSubiteration(moment.Iteration) ? moment : moment.PreviousIteration();
+            return DiagnoseFrame(prev.Frame, prev.Iteration);
         }
 
         public Rider GetFrame(Moment moment)

--- a/src/Game/Timeline.cs
+++ b/src/Game/Timeline.cs
@@ -16,6 +16,7 @@
 //  You should have received a copy of the GNU General Public License
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using linerider.Game.Physics;
 using linerider.Utils;
 using OpenTK;
 using OpenTK.Graphics;
@@ -114,6 +115,23 @@ namespace linerider.Game
                 }
             }
         }
+
+        /// <summary>
+        /// Extracts the rider and death details of the specified frame.
+        /// </summary>
+        public RiderFrame ExtractFrame(Moment moment)
+        {
+            Rider rider;
+            List<int> diagnosis = null;
+            using (_track.Grid.Sync.AcquireRead())
+            {
+                diagnosis = DiagnoseFrame(moment);
+                rider = GetFrame(moment);
+            }
+
+            return new RiderFrame(moment, rider, diagnosis);
+        }
+
         /// <summary>
         /// Extracts the rider and death details of the specified frame.
         /// </summary>
@@ -126,7 +144,7 @@ namespace linerider.Game
                 diagnosis = DiagnoseFrame(frame, iteration);
                 rider = GetFrame(frame, iteration);
             }
-            return new RiderFrame(frame, rider, diagnosis, iteration);
+            return new RiderFrame(new Moment(frame, iteration), rider, diagnosis);
         }
         /// <summary>
         /// Gets an up to date diagnosis state for the frame, recomputing if
@@ -145,6 +163,65 @@ namespace linerider.Game
                     _track.Bones,
                     Math.Min(6, iteration + 1));
         }
+        /// <summary>
+        /// Gets an up to date diagnosis state for the frame, recomputing if
+        /// necessary.
+        /// </summary>
+        public List<int> DiagnoseFrame(Moment moment)
+        {
+            if (moment.Subiteration == Moment.maxSubiteration(moment.Iteration)) return DiagnoseFrame(moment.Frame, moment.Iteration);
+            bool equal = false;
+            Rider? rider = null;
+            if (moment.Iteration == RiderConstants.Iterations)
+            {
+                equal = true;
+            }
+            else
+            {
+                Rider next = GetFrame(moment.Frame + 1);
+                rider = GetFrame(moment.Frame);
+            }
+            return equal
+                ? new List<int>()
+                : ((Rider)rider).Diagnose(
+                    _track.Grid,
+                    _track.Bones,
+                    moment.NextIteration());
+        }
+
+        public Rider GetFrame(Moment moment)
+        {
+            if ((moment.Iteration == 6 || moment.Frame <= 0) && moment.Subiteration == Moment.maxSubiteration(moment.Iteration))
+            {
+                return GetFrame(moment.Frame);
+            }
+
+            if (moment.Subiteration == Moment.maxSubiteration(moment.Iteration))
+            {
+                return GetFrame(moment.Frame, moment.Iteration);
+            }
+            
+            Rider past;
+            
+            if (moment.Iteration != 0)
+            {
+                past = GetFrame(moment.Frame - 1);
+                return past.Simulate(_track.Grid, _track.Bones,null, moment, frameid: moment.Frame);
+            }
+
+            if (moment.Frame <= 1)
+            {
+                past = GetFrame(0);
+                return past.Simulate(_track.Grid, _track.Bones, null, moment, frameid: 0);
+            }
+
+            var extra_past_frame = moment.Frame - 2;
+            var extra_past = GetFrame(extra_past_frame);
+
+            past = extra_past.Simulate(_track.Grid, _track.Bones,null, new Moment(extra_past_frame), frameid: extra_past_frame, momentumsubit: moment.Subiteration);
+            return past.Simulate(_track.Grid, _track.Bones, null, moment);
+        }
+
         /// <summary>
         /// Gets an up to date rider state for the frame, recomputing if
         /// necessary.

--- a/src/IO/TrackRecorder.cs
+++ b/src/IO/TrackRecorder.cs
@@ -172,7 +172,7 @@ namespace linerider.IO
                 Constants.TriggerLineColorChange = Color.FromArgb(255, game.Track.StartingLineColorR, game.Track.StartingLineColorG, game.Track.StartingLineColorB);
 
                 Game.Rider state = game.Track.GetStart();
-                int frame = Settings.LockTrackDuration ? game.Canvas.TrackDuration : flag.FrameID;
+                int frame = Settings.LockTrackDuration ? game.Canvas.TrackDuration : flag.Moment.Frame;
                 game.Canvas.SetCanvasSize(game.RenderSize.Width, game.RenderSize.Height);
                 game.Canvas.Layout();
 

--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -995,9 +995,8 @@ namespace linerider
                 StopHandTool();
                 if (!Track.Paused)
                     Track.TogglePause();
-                Track.NextFrame();
-                Invalidate();
-                Track.UpdateCamera();
+                Track.momentOffset.IncrementFrame();
+                Track.updateRenderRiderAndCamera();
                 if (CurrentTools.CurrentTool.IsMouseButtonDown)
                 {
                     CurrentTools.CurrentTool.OnMouseMoved(InputUtils.GetMouse());
@@ -1010,9 +1009,8 @@ namespace linerider
                 StopHandTool();
                 if (!Track.Paused)
                     Track.TogglePause();
-                Track.PreviousFrame();
-                Invalidate();
-                Track.UpdateCamera(true);
+                Track.momentOffset.DecrementFrame();
+                Track.updateRenderRiderAndCamera();
                 if (CurrentTools.CurrentTool.IsMouseButtonDown)
                 {
                     CurrentTools.CurrentTool.OnMouseMoved(InputUtils.GetMouse());
@@ -1041,18 +1039,9 @@ namespace linerider
 
                 if (!Track.Paused)
                     Track.TogglePause();
-
-                if (Track.IterationsOffset != 6)
-                {
-                    Track.IterationsOffset++;
-                }
-                else
-                {
-                    Track.NextFrame();
-                    Track.IterationsOffset = 0;
-                    Track.UpdateCamera();
-                }
-                Track.InvalidateRenderRider();
+                
+                Track.momentOffset.IncrementIteration();
+                Track.updateRenderRiderAndCamera();
             },
             null,
             repeat: true);
@@ -1062,21 +1051,26 @@ namespace linerider
                     return;
 
                 StopTools();
-                if (Track.IterationsOffset > 0)
-                {
-                    Track.IterationsOffset--;
-                }
-                else
-                {
-                    Track.PreviousFrame();
-                    Track.IterationsOffset = 6;
-                    Invalidate();
-                    Track.UpdateCamera();
-                }
-                Track.InvalidateRenderRider();
+                
+                Track.momentOffset.DecrementIteration();
+                Track.updateRenderRiderAndCamera();
             },
             null,
             repeat: true);
+            InputUtils.RegisterHotkey(Hotkey.PlaybackSubiterationNext, () => !Track.Playing, () =>
+            {
+                StopTools();
+                
+                Track.momentOffset.IncrementSubiteration();
+                Track.updateRenderRiderAndCamera();
+            }, repeat: true);
+            InputUtils.RegisterHotkey(Hotkey.PlaybackSubiterationPrev, () => !Track.Playing, () =>
+            {
+                StopTools();
+                
+                Track.momentOffset.DecrementSubiteration();
+                Track.updateRenderRiderAndCamera();
+            }, repeat: true);
             InputUtils.RegisterHotkey(Hotkey.PlaybackResetCamera, () => true, () => Track.ResetCamera());
             InputUtils.RegisterHotkey(Hotkey.PlaybackStart, () => true, () =>
             {

--- a/src/Rendering/RiderRenderer.cs
+++ b/src/Rendering/RiderRenderer.cs
@@ -44,7 +44,7 @@ namespace linerider.Rendering
                     GameDrawingMatrix.Scale / 2.5f);
             }
         }
-        public void DrawContacts(Rider rider, List<int> diagnosis, float opacity)
+        public void DrawContacts(Rider rider, List<int> diagnosis, float opacity, int subiteration = RiderConstants.Subiterations)
         {
             if (diagnosis == null)
                 diagnosis = new List<int>();
@@ -55,27 +55,49 @@ namespace linerider.Rendering
                 ? Constants.ConstraintRepelColor
                 : Constants.ConstraintColor;
 
+                float sizemult = 1;
+
+                if (subiteration != RiderConstants.Subiterations)
+                {
+                    if (i > subiteration)
+                    {
+                        constraintcolor = Color.Gray;
+                        sizemult = 0.5f;
+                    }
+
+                    if (i < subiteration)
+                    {
+                        constraintcolor = Color.Lime;
+                        sizemult = 0.5f;
+                    }
+
+                    if (i == subiteration)
+                    {
+                        constraintcolor = Color.Cyan;
+                    }
+                }
+
                 constraintcolor = ChangeOpacity(constraintcolor, opacity);
 
-                if (bones[i].Breakable)
+                if (bones[i].Breakable && subiteration == RiderConstants.Subiterations)
                 {
                     continue;
                 }
-                else if (bones[i].OnlyRepel)
+                else if (bones[i].OnlyRepel && subiteration == RiderConstants.Subiterations)
                 {
                     _lines.AddLine(
                         GameDrawingMatrix.ScreenCoordD(rider.Body[bones[i].joint1].Location),
                         GameDrawingMatrix.ScreenCoordD(rider.Body[bones[i].joint2].Location),
                         constraintcolor,
-                        GameDrawingMatrix.Scale / 4);
+                        GameDrawingMatrix.Scale / 4 * sizemult);
                 }
-                else if (i <= 3)
+                else if (i <= 3 || subiteration != RiderConstants.Subiterations)
                 {
                     _lines.AddLine(
                         GameDrawingMatrix.ScreenCoordD(rider.Body[bones[i].joint1].Location),
                         GameDrawingMatrix.ScreenCoordD(rider.Body[bones[i].joint2].Location),
                         constraintcolor,
-                        GameDrawingMatrix.Scale / 4);
+                        GameDrawingMatrix.Scale / 4 * sizemult);
                 }
             }
             if (!rider.Crashed && diagnosis.Count != 0)

--- a/src/Rendering/SimulationRenderer.cs
+++ b/src/Rendering/SimulationRenderer.cs
@@ -80,8 +80,8 @@ namespace linerider.Rendering
                 _riderrenderer.DrawMomentum(options.Rider, 1);
                 if (
                     !options.IsRunning &&
-                    options.Iteration != 6 &&
-                    options.Iteration != 0 &&
+                    options.Moment.Iteration != 6 &&
+                    options.Moment.Iteration != 0 &&
                     !Settings.OnionSkinning)
                 {
                     Rider frame = timeline.GetFrame(game.Track.Offset + 1, 0);
@@ -94,7 +94,7 @@ namespace linerider.Rendering
             }
             if (options.ShowContactLines)
             {
-                _riderrenderer.DrawContacts(options.Rider, options.RiderDiagnosis, 1);
+                _riderrenderer.DrawContacts(options.Rider, options.RiderDiagnosis, 1, options.Moment.Iteration == 0 ? RiderConstants.Subiterations : options.Moment.Subiteration);
             }
             _riderrenderer.Scale = options.Zoom;
             _riderrenderer.Draw();

--- a/src/UI/Hotkey.cs
+++ b/src/UI/Hotkey.cs
@@ -64,6 +64,8 @@ namespace linerider.UI
         PlaybackFramePrev,
         PlaybackIterationNext,
         PlaybackIterationPrev,
+        PlaybackSubiterationNext,
+        PlaybackSubiterationPrev,
         PlaybackTogglePause,
         PlaybackForward,
         PlaybackBackward,

--- a/src/UI/Widgets/Preferences/HotkeysEditor.cs
+++ b/src/UI/Widgets/Preferences/HotkeysEditor.cs
@@ -133,6 +133,8 @@ namespace linerider.UI.Widgets
             AddBinding(playbackTable, "Frame Previous", Hotkey.PlaybackFramePrev);
             AddBinding(playbackTable, "Iteration Next", Hotkey.PlaybackIterationNext);
             AddBinding(playbackTable, "Iteration Previous", Hotkey.PlaybackIterationPrev);
+            AddBinding(playbackTable, "Subiteration Next", Hotkey.PlaybackSubiterationNext);
+            AddBinding(playbackTable, "Subiteration Previous", Hotkey.PlaybackSubiterationPrev);
             AddBinding(playbackTable, "Hold -- Forward", Hotkey.PlaybackForward);
             AddBinding(playbackTable, "Hold -- Rewind", Hotkey.PlaybackBackward);
             AddBinding(playbackTable, "Increase Playback Rate", Hotkey.PlaybackSpeedUp);

--- a/src/UI/Widgets/TimelineBar.cs
+++ b/src/UI/Widgets/TimelineBar.cs
@@ -116,6 +116,7 @@ namespace linerider.UI.Widgets
                 Alignment = Pos.Center,
                 TextRequest = (o, e) =>
                 {
+                    return _editor.momentOffset.displayString();
                     int iteration = _editor.IterationsOffset;
                     if (iteration == 6)
                         return "";
@@ -179,7 +180,7 @@ namespace linerider.UI.Widgets
             _playheadLimiter.IsHidden = Settings.LockTrackDuration;
 
             if (!_playheadFlag.IsHeld && _editor.HasFlag)
-                _playheadFlag.Value = _editor.Flag.FrameID;
+                _playheadFlag.Value = _editor.Flag.Moment.Frame;
 
             _totalTime.Font = _playheadLimiter.IsHeld ? _canvas.Fonts.DefaultBold : _canvas.Fonts.Default;
             _flagTime.Font = _playheadFlag.IsHeld ? _canvas.Fonts.DefaultBold : _canvas.Fonts.Default;

--- a/src/UI/Widgets/TimelineBar.cs
+++ b/src/UI/Widgets/TimelineBar.cs
@@ -114,20 +114,7 @@ namespace linerider.UI.Widgets
             {
                 Dock = Dock.Fill,
                 Alignment = Pos.Center,
-                TextRequest = (o, e) =>
-                {
-                    return _editor.momentOffset.displayString();
-                    int iteration = _editor.IterationsOffset;
-                    if (iteration == 6)
-                        return "";
-
-                    string label = $"Physics Iteration: {iteration}";
-
-                    if (iteration == 0)
-                        label += " (momentum tick)";
-
-                    return label;
-                },
+                TextRequest = (o, e) => _editor.momentOffset.displayString()
             };
             _ = new TrackLabel(textPanel)
             {

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -452,6 +452,8 @@ namespace linerider
             SetupDefaultKeybind(Hotkey.PlaybackBackward, new Keybinding(Key.Left, KeyModifiers.Shift));
             SetupDefaultKeybind(Hotkey.PlaybackIterationNext, new Keybinding(Key.Right, KeyModifiers.Alt));
             SetupDefaultKeybind(Hotkey.PlaybackIterationPrev, new Keybinding(Key.Left, KeyModifiers.Alt));
+            SetupDefaultKeybind(Hotkey.PlaybackSubiterationNext, new Keybinding(Key.Right, KeyModifiers.Control));
+            SetupDefaultKeybind(Hotkey.PlaybackSubiterationPrev, new Keybinding(Key.Left, KeyModifiers.Control));
             SetupDefaultKeybind(Hotkey.PlaybackTogglePause, new Keybinding(Key.Space));
 
             SetupDefaultKeybind(Hotkey.PreferencesWindow,


### PR DESCRIPTION
Closes #68 
theres a new type for physics "Moments" which are a combination of frame, iteration, and subiteration.

the editor now has a `momentOffset` field for the currently viewed frame. the old `Offset` and `IterationsOffset` were changed to reference the `momentOffset` so any code that still uses them works the same.

iteration 0 has four subiterations, some of them don't actually exist as intermediate steps in the physics but are useful for visualization, they are in this order:
- momentum (as if no friction or red lines happened in the previous frame, and gravity didnt apply)
- friction (as if no red lines happened in the previous frame, and gravity didnt apply)
- acceleration (as if gravity didnt apply)
- gravity (the final position of the momentum tick)

the other iterations have one subiteration for each bone and then one where all the lines apply