### PR TITLE
cache ClientSize

### DIFF
--- a/src/MainWindow.cs
+++ b/src/MainWindow.cs
@@ -92,6 +92,12 @@ namespace linerider
                 RenderSize.Width,
                 RenderSize.Height).Vector;
 
+        public new Vector2i ClientSize
+        {
+            get => cachedClientSize;
+            set => base.ClientSize = value;
+        }
+        Vector2i cachedClientSize = Vector2i.Zero;
         public Editor Track { get; }
         private bool _uicursor = false;
         private Gwen.Input.OpenTK _input;
@@ -112,6 +118,7 @@ namespace linerider
             WindowBorder = WindowBorder.Resizable;
             RenderFrame += (o) => { Render(); };
             UpdateFrame += (o) => { GameUpdate(); };
+            Resize += (o) => { cachedClientSize = o.Size; };
             new Thread(AutosaveThreadRunner) { IsBackground = true, Name = "Autosave" }.Start();
             GameService.Initialize(this);
             AddonManager.Initialize(this);


### PR DESCRIPTION
for whatever reason (and it seems like this was linux-specific) the getter for `ClientSize` property on opentk's NativeWindow would take a *reaaaaaaaally* long time to call. this happened many times a frame, proportional to the amounts of riders and other things being rendered, which meant onion skinning was unusable on linux.

instead of dealing with any of that, save a copy of the size whenever we get a resize event. 
this took me from having like 9 fps with 20 onion skin frames to having 60 fps with 400 of them.