### PR TITLE
Lifelock Strain Constraint

### DIFF
--- a/src/Game/Physics/Rider.cs
+++ b/src/Game/Physics/Rider.cs
@@ -110,6 +110,16 @@ namespace linerider.Game
             return anchorsaverage / Body.Length;
         }
 
+        public double CalculateStrain(Bone[] bones)
+        {
+            double strain = 0.0;
+            foreach (Bone bone in bones)
+            {
+                strain += Math.Abs(bone.RestLength * (bone.OnlyRepel ? 2.0 : 1.0) - (Body[bone.joint1].Location - Body[bone.joint2].Location).Length);
+            }
+            return strain;
+        }
+
         public Vector2d CalculateMomentum()
         {
             Vector2d mo = Vector2d.Zero;

--- a/src/Game/Timeline.cs
+++ b/src/Game/Timeline.cs
@@ -37,6 +37,14 @@ namespace linerider.Game
         private readonly ResourceSync _framesync = new();
         private readonly AutoArray<FrameInfo> _frames = new();
         private readonly Track _track;
+
+        public Bone[] Bones
+        {
+            get
+            {
+                return _track.Bones;
+            }
+        }
         public event EventHandler<int> FrameInvalidated;
         public Timeline(Track track)
         {

--- a/src/Tools/Tool.cs
+++ b/src/Tools/Tool.cs
@@ -310,6 +310,13 @@ namespace linerider.Tools
             int iteration = game.Track.IterationsOffset;
             if (offset == 0)
                 return false;
+            if (Settings.Editor.LifeLockStrainConstraint)
+            {
+                Rider _6th_it = timeline.GetFrame(offset);
+                double strain = _6th_it.CalculateStrain(timeline.Bones);
+                if (strain > Settings.Editor.LifeLockMaxStrain)
+                    return false;
+            }
             Rider frame = timeline.GetFrame(offset, iteration);
             if (!frame.Crashed)
             {

--- a/src/UI/Dialogs/PreferencesWindow.cs
+++ b/src/UI/Dialogs/PreferencesWindow.cs
@@ -664,6 +664,28 @@ namespace linerider.UI
                 Settings.Editor.LifeLockNoFakie = ((Checkbox)o).IsChecked;
                 Settings.Save();
             });
+            
+            Spinner max_strain = new(lifelockGroup)
+            {
+                Min = 0,
+                Max = 99999999999,
+                Value = Settings.Editor.LifeLockMaxStrain,
+                IncrementSize = 0.1,
+                IsDisabled = !Settings.Editor.LifeLockStrainConstraint,
+            };
+            max_strain.ValueChanged += (o, e) =>
+            {
+                Settings.Editor.LifeLockMaxStrain = (float)((Spinner)o).Value;
+                Settings.Save();
+            };
+            
+            _ = GwenHelper.AddCheckbox(lifelockGroup, "Use Strain Constraint", Settings.Editor.LifeLockStrainConstraint, (o, e) =>
+            {
+                Settings.Editor.LifeLockStrainConstraint = ((Checkbox)o).IsChecked;
+                max_strain.IsDisabled = !Settings.Editor.LifeLockStrainConstraint;
+                Settings.Save();
+            });
+            _ = GwenHelper.CreateLabeledControl(lifelockGroup, "Max Strain", max_strain);
 
             Panel snappingGroup = GwenHelper.CreateHeaderPanel(parent, "Snapping");
 

--- a/src/Utils/Settings.cs
+++ b/src/Utils/Settings.cs
@@ -77,6 +77,8 @@ namespace linerider
             public static bool DrawContactPoints;
             public static bool LifeLockNoOrange;
             public static bool LifeLockNoFakie;
+            public static bool LifeLockStrainConstraint;
+            public static float LifeLockMaxStrain;
             public static bool ShowLineLength;
             public static bool ShowLineAngle;
             public static bool ShowLineID;
@@ -278,6 +280,8 @@ namespace linerider
             Editor.DrawContactPoints = false;
             Editor.LifeLockNoOrange = false;
             Editor.LifeLockNoFakie = false;
+            Editor.LifeLockStrainConstraint = false;
+            Editor.LifeLockMaxStrain = 100.0f;
             Editor.ShowLineLength = true;
             Editor.ShowLineAngle = true;
             Editor.ShowLineID = false;
@@ -714,6 +718,8 @@ namespace linerider
             LoadBool(GetSetting(lines, nameof(Editor.ShowCoordinateMenu)), ref Editor.ShowCoordinateMenu);
             LoadBool(GetSetting(lines, nameof(Editor.LifeLockNoFakie)), ref Editor.LifeLockNoFakie);
             LoadBool(GetSetting(lines, nameof(Editor.LifeLockNoOrange)), ref Editor.LifeLockNoOrange);
+            LoadBool(GetSetting(lines, nameof(Editor.LifeLockStrainConstraint)), ref Editor.LifeLockStrainConstraint);
+            LoadFloat(GetSetting(lines, nameof(Editor.LifeLockMaxStrain)), ref Editor.LifeLockMaxStrain);
             LoadBool(GetSetting(lines, nameof(LimitLineKnobsSize)), ref LimitLineKnobsSize);
             LoadInt(GetSetting(lines, nameof(SettingsPane)), ref SettingsPane);
             LoadBool(GetSetting(lines, nameof(MuteAudio)), ref MuteAudio);
@@ -852,6 +858,8 @@ namespace linerider
                 MakeSetting(nameof(Editor.ShowCoordinateMenu), Editor.ShowCoordinateMenu.ToString(Program.Culture)),
                 MakeSetting(nameof(Editor.LifeLockNoFakie), Editor.LifeLockNoFakie.ToString(Program.Culture)),
                 MakeSetting(nameof(Editor.LifeLockNoOrange), Editor.LifeLockNoOrange.ToString(Program.Culture)),
+                MakeSetting(nameof(Editor.LifeLockStrainConstraint), Editor.LifeLockStrainConstraint.ToString(Program.Culture)),
+                MakeSetting(nameof(Editor.LifeLockMaxStrain), Editor.LifeLockMaxStrain.ToString(Program.Culture)),
                 MakeSetting(nameof(LimitLineKnobsSize), LimitLineKnobsSize.ToString(Program.Culture)),
                 MakeSetting(nameof(SettingsPane), SettingsPane.ToString(Program.Culture)),
                 MakeSetting(nameof(MuteAudio), MuteAudio.ToString(Program.Culture)),


### PR DESCRIPTION
adds a setting for lifelock where you can limit the max strain so that it doesn't lock if bosh is under more strain than the limit.

strain is measured as the sum of all the bones' difference from rest length.

this makes smooth chains much faster to make because it can lock on the same strain value for each pull.